### PR TITLE
Update Ext_T_AmmoRegHelp.uc

### DIFF
--- a/ServerExt/Classes/Ext_T_AmmoRegHelp.uc
+++ b/ServerExt/Classes/Ext_T_AmmoRegHelp.uc
@@ -15,6 +15,7 @@ function Timer()
 {
 	local KFWeapon W;
 	local byte i;
+	local int extraAmmo;
 
 	if( PawnOwner==None || PawnOwner.Health<=0 || PawnOwner.InvManager==None )
 		Destroy();
@@ -27,6 +28,14 @@ function Timer()
 				if( W.SpareAmmoCount[i]<W.SpareAmmoCapacity[i] )
 				{
 					W.SpareAmmoCount[i] = Min(W.SpareAmmoCount[i]+FMax(float(W.SpareAmmoCapacity[i])*RegCount,1.f),W.SpareAmmoCapacity[i]);
+					extraAmmo = W.SpareAmmoCount[i];
+					if (i==0)
+                        			W.AddAmmo(extraAmmo);
+                    			else
+                    			{
+                        			W.AddSecondaryAmmo(extraAmmo);
+                        			W.ClientForceSecondaryAmmoUpdate(W.AmmoCount[i]);
+                    			}
 					W.bNetDirty = true;
 				}
 			}


### PR DESCRIPTION
This got suggested by a friend as a way to force M16 / 501 grenade ammo to regen appropriately; apparently it's how ZedTernal accomplishes such successfully? Tested via mando on M16 and 501, saw proper behavior + no dud nades.

I'm not entirely sure what the code is doing here, to be very honest. If you have insight, that'd be appreciated.