### PR TITLE
Update Ext_T_AmmoRegHelp.uc

### DIFF
--- a/ServerExt/Classes/Ext_T_AmmoRegHelp.uc
+++ b/ServerExt/Classes/Ext_T_AmmoRegHelp.uc
@@ -27,6 +27,7 @@ function Timer()
 				if( W.SpareAmmoCount[i]<W.SpareAmmoCapacity[i] )
 				{
 					W.SpareAmmoCount[i] = Min(W.SpareAmmoCount[i]+FMax(float(W.SpareAmmoCapacity[i])*RegCount,1.f),W.SpareAmmoCapacity[i]);
+					W.ClientForceSecondaryAmmoUpdate(W.AmmoCount[i]);
 					W.bNetDirty = true;
 				}
 			}


### PR DESCRIPTION
I see what you were saying, how the ammo added was ridiculous. Adding in just the W.ClientForceSecondaryAmmoUpdate(W.AmmoCount[i]); does, in fact, add grenades that fire - the only hitch I was encountering was that I was getting a grenade, from empty, and couldn't force the reload with alt fire - the reload had to happen from either a weapon switch or tapping R?

Side note, I noticed while I was testing that it wasn't giving 10% at ammo regen level 3 - AR15 was getting 24 rounds every 30s, while the M16 was getting 27, vice the respective 26 and 30 I was expecting based on spare ammo count with 0 points invested (260 and 300 pool for each). Is this something that's been an issue and hasn't been noticed?